### PR TITLE
Add travis ci testing configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+---
+  language: objective-c
+
+  script: travis/script.sh

--- a/Readme.markdown
+++ b/Readme.markdown
@@ -1,5 +1,8 @@
 # TMInstanceMethodSwizzler & TMTimeoutManager
 
+.. image:: https://travis-ci.org/jplana/TMInstanceMethodSwizzler.png?branch=master
+   :target: https://travis-ci.org/jplana/TMInstanceMethodSwizzler
+
 `TMInstanceMethodSwizzler` is a class which allows you to replace or modify an object's method implementation without affecting any other objects of the same class and without side effects either. It might be useful, for instance, to implement Aspect Oriented Programing and to create partial object mocks for testing. You can whatch this [YouTube video](http://www.youtube.com/watch?v=VS9gWhZUpVg) to know about it in greater detail.
 
 `TMTimeoutManager` is an example of use of the previous, which allows you to observe an object's method to be called before a certain timeout and specifying different blocks of code to be invoked depending on whether the method is called or not.

--- a/Sample app/TMInstanceMethodSwizzler sample.xcodeproj/xcshareddata/xcschemes/TMInstanceMethodSwizzler sample.xcscheme
+++ b/Sample app/TMInstanceMethodSwizzler sample.xcodeproj/xcshareddata/xcschemes/TMInstanceMethodSwizzler sample.xcscheme
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0500"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1AB85FF318AE949C00B7A18C"
+               BuildableName = "TMInstanceMethodSwizzler sample.app"
+               BlueprintName = "TMInstanceMethodSwizzler sample"
+               ReferencedContainer = "container:TMInstanceMethodSwizzler sample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1AB8601418AE949C00B7A18C"
+               BuildableName = "TMInstanceMethodSwizzler sampleTests.xctest"
+               BlueprintName = "TMInstanceMethodSwizzler sampleTests"
+               ReferencedContainer = "container:TMInstanceMethodSwizzler sample.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1AB85FF318AE949C00B7A18C"
+            BuildableName = "TMInstanceMethodSwizzler sample.app"
+            BlueprintName = "TMInstanceMethodSwizzler sample"
+            ReferencedContainer = "container:TMInstanceMethodSwizzler sample.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1AB85FF318AE949C00B7A18C"
+            BuildableName = "TMInstanceMethodSwizzler sample.app"
+            BlueprintName = "TMInstanceMethodSwizzler sample"
+            ReferencedContainer = "container:TMInstanceMethodSwizzler sample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1AB85FF318AE949C00B7A18C"
+            BuildableName = "TMInstanceMethodSwizzler sample.app"
+            BlueprintName = "TMInstanceMethodSwizzler sample"
+            ReferencedContainer = "container:TMInstanceMethodSwizzler sample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+xctool -project Sample\ app/TMInstanceMethodSwizzler\ sample.xcodeproj -scheme TMInstanceMethodSwizzler\ sample -sdk iphonesimulator test 


### PR DESCRIPTION
This PR should provide base for an automated travis testing.  

It works by adding:
1. the main `.travis.yml`configuration
2. a shell script using xctool to build & test the application provided
3. a shared scheme needed by the xctool needed by the tool to compile (the project is compiled by the travis user in the CI environment)

It also adds the travis badge in the README.markdown, but obviously it would have to be modified before merging to point to your repository. 

Let me know if I can improve the build/test process somehow. 
