### PR TITLE
Update README.md to show Travis-CI label properly

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -1,7 +1,5 @@
 # TMInstanceMethodSwizzler & TMTimeoutManager
-
-.. image:: https://travis-ci.org/jplana/TMInstanceMethodSwizzler.png?branch=master
-   :target: https://travis-ci.org/jplana/TMInstanceMethodSwizzler
+[![Build Status](https://travis-ci.org/jplana/TMInstanceMethodSwizzler.svg?branch=add-travis-ci-testing-configuration)](https://travis-ci.org/jplana/TMInstanceMethodSwizzler)
 
 `TMInstanceMethodSwizzler` is a class which allows you to replace or modify an object's method implementation without affecting any other objects of the same class and without side effects either. It might be useful, for instance, to implement Aspect Oriented Programing and to create partial object mocks for testing. You can whatch this [YouTube video](http://www.youtube.com/watch?v=VS9gWhZUpVg) to know about it in greater detail.
 


### PR DESCRIPTION
This readme file had a wrong reference to the Travis-CI system. With this fix, this readme will show a green label to the library users ;)
